### PR TITLE
CONFIG #45 substitute env vars with webpack

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,10 +4,8 @@
     "description": "Pokemon Battle Sim",
     "scripts": {
         "prebuild": "del-cli build",
-        "build": "webpack --mode production",
-        "build-serve": "webpack --mode production && webpack-dev-server --mode production",
-        "dev": "webpack --mode development && webpack-dev-server --mode development",
-        "dev:server": "cd ../server && npm run dev",
+        "build": "NODE_ENV=production webpack --mode production",
+        "dev": "webpack --mode development  && webpack-dev-server --mode development",
         "lint": "npm run lint:eslint:fix && npm run lint:prettier:fix",
         "lint:eslint": "eslint -c .eslintrc.js --ext .ts .",
         "lint:eslint:fix": "npm run lint:eslint -- --fix",

--- a/web/src/dev-config.ts
+++ b/web/src/dev-config.ts
@@ -1,8 +1,8 @@
 // TODO make dev easy again
-export const isProd = true; // window.location.hostname !== "localhost";
+export const isProd = process.env.NODE_ENV === "production";
 export const DEV = isProd
     ? {}
     : {
-          inBattleImmediately: false,
+          inBattleImmediately: true,
           enableSceneWatcher: false,
       };

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -5,6 +5,9 @@ main();
 
 function main() {
     window.addEventListener("load", () => {
+        console.log("version:", process.env.GIT_VERSION);
+        console.log("git commit date:", process.env.GIT_AUTHOR_DATE);
+        console.log("env:", process.env.NODE_ENV);
         new Game(gameConfig);
     });
 }

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -1,8 +1,13 @@
+const child_process = require("child_process");
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CopyPlugin = require("copy-webpack-plugin");
+const { EnvironmentPlugin, ProgressPlugin } = require("webpack");
 const pathToPhaser = path.join(__dirname, "/node_modules/phaser/");
 const phaser = path.join(pathToPhaser, "dist/phaser.js");
+
+const git = (command) =>
+    child_process.execSync(`git ${command}`, { encoding: "utf8" }).trim();
 
 module.exports = {
     entry: "./src/index.ts",
@@ -22,6 +27,7 @@ module.exports = {
         host: "localhost",
         port: 8080,
         open: true,
+        hot: true, // TODO does this help?
     },
     resolve: {
         extensions: [".ts", ".js"],
@@ -30,6 +36,7 @@ module.exports = {
         },
     },
     plugins: [
+        new ProgressPlugin(),
         new HtmlWebpackPlugin({
             template: "./index.template.html",
             filename: "index.html",
@@ -40,6 +47,13 @@ module.exports = {
                 { from: "assets", to: "assets" },
                 { from: "index.css", to: "index.css" },
             ],
+        }),
+        // Note: setting environment variables in your shell will overwrite these values
+        new EnvironmentPlugin({
+            GIT_VERSION: git("describe --always"),
+            GIT_AUTHOR_DATE: git("log -1 --format=%aI"),
+            PRODUCTION: "false",
+            NODE_ENV: "development",
         }),
     ],
 };


### PR DESCRIPTION
- ADD version (in form of git commit sha) gets printed to console on opening the webpage
- REFACTOR automatically set `isProd` variable to choose URL for mock or backend