### PR TITLE
CONFIG #44 reduce bundle size from 1.2MiB to 1.0MiB with uglify

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12116,6 +12116,43 @@
             "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
             "dev": true
         },
+        "uglify-js": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.1.tgz",
+            "integrity": "sha512-JhS3hmcVaXlp/xSo3PKY5R0JqKs5M3IV+exdLHW99qKvKivPO4Z8qbej6mte17SOPqAOVMjt/XGgWacnFSzM3g==",
+            "dev": true
+        },
+        "uglifyjs-webpack-plugin": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz",
+            "integrity": "sha512-mHSkufBmBuJ+KHQhv5H0MXijtsoA1lynJt1lXOaotja8/I0pR4L9oGaPIZw+bQBOFittXZg9OC1sXSGO9D9ZYg==",
+            "dev": true,
+            "requires": {
+                "cacache": "^12.0.2",
+                "find-cache-dir": "^2.1.0",
+                "is-wsl": "^1.1.0",
+                "schema-utils": "^1.0.0",
+                "serialize-javascript": "^1.7.0",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.6.0",
+                "webpack-sources": "^1.4.0",
+                "worker-farm": "^1.7.0"
+            },
+            "dependencies": {
+                "serialize-javascript": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+                    "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
         "unbox-primitive": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -52,6 +52,7 @@
         "ts-loader": "7.0.4",
         "ts-node": "^8.10.2",
         "typescript": "4.x",
+        "uglifyjs-webpack-plugin": "^2.2.0",
         "webpack": "4.43.0",
         "webpack-cli": "3.3.12",
         "webpack-dev-server": "3.11.0"

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -3,6 +3,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CopyPlugin = require("copy-webpack-plugin");
 const pathToPhaser = path.join(__dirname, "/node_modules/phaser/");
 const phaser = path.join(pathToPhaser, "dist/phaser.js");
+const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 
 module.exports = {
     entry: "./src/index.ts",
@@ -28,6 +29,23 @@ module.exports = {
         alias: {
             phaser,
         },
+    },
+    optimization: {
+        minimizer: [
+            new UglifyJsPlugin({
+                uglifyOptions: {
+                    warnings: false,
+                    parse: {},
+                    compress: {},
+                    mangle: true,
+                    output: null,
+                    toplevel: false,
+                    nameCache: null,
+                    ie8: false,
+                    keep_fnames: false,
+                },
+            }),
+        ],
     },
     plugins: [
         new HtmlWebpackPlugin({

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -34,15 +34,7 @@ module.exports = {
         minimizer: [
             new UglifyJsPlugin({
                 uglifyOptions: {
-                    warnings: false,
-                    parse: {},
-                    compress: {},
-                    mangle: true,
                     output: null,
-                    toplevel: false,
-                    nameCache: null,
-                    ie8: false,
-                    keep_fnames: false,
                 },
             }),
         ],


### PR DESCRIPTION
Using uglifyjs plugin for webpack (our frontend build tool), we reduce from 1.2MiB to 1MiB, saving 16.6% in bundle size


Why is this important? Smaller bundle size reduces the amount of data a user has to download thus saving the user's and our bandwidth (which we have to pay for depending on the web hosting provider)

Tradeoffs: unreadable source maps, `npm run build` time increases slightly